### PR TITLE
Fixed typo in settings.py file

### DIFF
--- a/AcadeMe/settings.py
+++ b/AcadeMe/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'AcadeMeData.apps.AcadeMeDataConfig',
+    'AcadeMeData.apps.AcademedataConfig',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
This typo was in AcademedataConfig class name
this issue caused an error in running the server
and trying to display the landing page.